### PR TITLE
Option to enable multiple vifs

### DIFF
--- a/bin/setup_nw_eden
+++ b/bin/setup_nw_eden
@@ -8,6 +8,9 @@ sudo ip link add vxlan100 type vxlan id 100 local $EDEN_IP remote $OS_IP dstport
 sudo brctl addbr br-os
 sudo brctl addif br-os tap0
 sudo brctl addif br-os vxlan100
+# disable mac learning allow us to have multiple VMs in one EVE-OS
+# WARNING: TESTED ONLY IN MULTINODE MODE
+sudo brctl setageing br-os 0
 
 for i in vxlan100 br-os tap0
 do

--- a/bin/setup_nw_eden.multinode
+++ b/bin/setup_nw_eden.multinode
@@ -3,6 +3,8 @@
 sudo tunctl -t tap0 -u `whoami`
 sudo brctl addbr br-eve
 sudo brctl addif br-eve tap0
+# disable mac learning allow us to have multiple VMs in one EVE-OS
+sudo brctl setageing br-eve 0
 
 for i in br-eve tap0 br-int br-tun ovs-system
 do


### PR DESCRIPTION
Disable of mac learning allow us to have multiple VMs in one EVE-OS